### PR TITLE
Fixed "local" socket support along with concat ordering

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -65,21 +65,21 @@ define opendkim::domain(
   concat::fragment{ "signingtable_${name}":
     target  => '/etc/opendkim_signingtable.conf',
     content => "${signing_key} ${selector}._domainkey.${domain}\n",
-    order   => 10,
+    order   => "10 ${name}",
     require => File[$key_file],
   }
   if ($subdomains) {
     concat::fragment{ "signingtable_${name}_subdomains":
       target  => '/etc/opendkim_signingtable.conf',
       content => ".${signing_key} ${selector}._domainkey.${domain}\n",
-      order   => 10,
+      order   => "10 ${name}",
       require => File[$key_file],
     }
   }
   concat::fragment{ "keytable_${name}":
     target  => '/etc/opendkim_keytable.conf',
     content => "${selector}._domainkey.${domain} ${domain}:${selector}:${key_file}\n",
-    order   => 10,
+    order   => "10 ${name}",
     require => File[$key_file],
   }
 }

--- a/manifests/socket.pp
+++ b/manifests/socket.pp
@@ -7,7 +7,7 @@
 # [*type*]
 #   Your MTA and your opendkim filter will communicate over a socket
 #   connection. Set type to 'inet' for a TCP network socket or to
-#   'file' for a UNIX filesystem socket.
+#   'local' for a UNIX filesystem socket.
 #   They each have advantages: A UNIX socket can be secured using the
 #   filesystem (i.e., with user or group permissions), but cannot be
 #   reached from other machines that might want to share the service.
@@ -57,7 +57,7 @@ define opendkim::socket(
         default => "${type}:${port}@${interface}",
       }
     }
-    'file': {
+    'local': {
       $socket = "${type}:${file}"
     }
     default: {

--- a/manifests/socket.pp
+++ b/manifests/socket.pp
@@ -67,7 +67,7 @@ define opendkim::socket(
   concat::fragment{ $socket:
     target  => '/etc/default/opendkim',
     content => "SOCKET=${socket} # ${name}\n",
-    order   => 10;
+    order   => "10 ${name}";
   }
 }
 


### PR DESCRIPTION
Hi!

The UNIX sockets support is currently broken (in the original module and the fork), since the proper type name is "local" instead of "file". This PR fixes the problem.
Also, the more deterministic concat ordering is used.
